### PR TITLE
Uses milliseconds in a year to calculate PI

### DIFF
--- a/compute_PI/datetime-PI.py
+++ b/compute_PI/datetime-PI.py
@@ -1,0 +1,22 @@
+import time
+from datetime import datetime, timedelta
+from test_PI import test_PI
+
+
+def datetimePI():
+    seconds = 365 * 24 * 60 * 60  # Seconds passing in a year
+    milliseconds = 996  # We want to get milliseconds of a year when we know the end result will be smaller than PI
+    step = 0.000001  # then increase the milliseconds in very small steps
+    while True:
+        try:
+            current_day_in_seconds = time.time()
+            epoch_time_a_year_ago = (datetime.today() - timedelta(milliseconds=seconds * milliseconds)).timestamp()
+            pi = (current_day_in_seconds - epoch_time_a_year_ago) / 10000000
+            test_PI(pi)
+            print('Found PI from date %s' % datetime.fromtimestamp(epoch_time_a_year_ago).isoformat())
+            break
+        except AssertionError:
+            milliseconds = milliseconds + step
+
+
+datetimePI()

--- a/compute_PI/datetime-PI.py
+++ b/compute_PI/datetime-PI.py
@@ -14,9 +14,9 @@ def datetimePI():
             pi = (current_day_in_seconds - epoch_time_a_year_ago) / 10000000
             test_PI(pi)
             print('Found PI from date %s' % datetime.fromtimestamp(epoch_time_a_year_ago).isoformat())
-            break
+            return pi
         except AssertionError:
             milliseconds = milliseconds + step
 
 
-datetimePI()
+print(datetimePI())

--- a/compute_PI/datetime-PI.py
+++ b/compute_PI/datetime-PI.py
@@ -19,4 +19,4 @@ def datetimePI():
             milliseconds = milliseconds + step
 
 
-print(datetimePI())
+datetimePI()


### PR DESCRIPTION
Fun Fact the seconds in a year are approximately PI to the seventh power of 10. This uses this coincidence to approximate pi. And gives you the result Date.